### PR TITLE
Add M&A contract quality check notebook

### DIFF
--- a/quality_check_demo.ipynb
+++ b/quality_check_demo.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## M&A Quality Check Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install python-docx flask langchain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from docx import Document\n",
+    "\n",
+    "def create_doc(filename, indemnity=True, non_compete=True, law=True):\n",
+    "    doc = Document()\n",
+    "    doc.add_heading(\"M&A Agreement\", level=1)\n",
+    "    doc.add_paragraph(\"Date: 2024-01-01\")\n",
+    "    doc.add_paragraph(\"Parties: Acme Corp and Target LLC\")\n",
+    "    if indemnity:\n",
+    "        doc.add_paragraph(\"Indemnity: The parties agree to indemnify each other.\")\n",
+    "    if non_compete:\n",
+    "        doc.add_paragraph(\"Non-compete: The seller shall not compete.\")\n",
+    "    if law:\n",
+    "        doc.add_paragraph(\"Governing Law: Delaware applies.\")\n",
+    "    doc.save(filename)\n",
+    "\n",
+    "create_doc('doc123.docx', indemnity=False)\n",
+    "create_doc('doc124.docx', non_compete=False, law=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flask import Flask, request, jsonify\n",
+    "from docx import Document\n",
+    "import threading\n",
+    "\n",
+    "app = Flask(__name__)\n",
+    "\n",
+    "CLAUSES = {\n",
+    "    'indemnity': 'indemnity',\n",
+    "    'non-compete': 'non-compete',\n",
+    "    'governing-law': 'governing law'\n",
+    "}\n",
+    "\n",
+    "def check_contract(path):\n",
+    "    doc = Document(path)\n",
+    "    text = '\n'.join(p.text.lower() for p in doc.paragraphs)\n",
+    "    missing = [c for c, k in CLAUSES.items() if k not in text]\n",
+    "    result = {\n",
+    "        'missing_clauses': missing,\n",
+    "        'date_mismatch': '2024' not in text,\n",
+    "        'entity_mismatch': 'acme corp' not in text\n",
+    "    }\n",
+    "    return result\n",
+    "\n",
+    "@app.route('/mcp/quality', methods=['POST'])\n",
+    "def quality():\n",
+    "    data = request.json\n",
+    "    return jsonify(check_contract(data['path']))\n",
+    "\n",
+    "threading.Thread(target=app.run, kwargs={'port': 5000}, daemon=True).start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.tools import tool\n",
+    "import requests\n",
+    "\n",
+    "@tool\n",
+    "def run_quality_check(path: str) -> dict:\n",
+    "    \"\"\"send file path to quality server\"\"\"\n",
+    "    r = requests.post('http://localhost:5000/mcp/quality', json={'path': path})\n",
+    "    return r.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.chat_models import ChatOllama\n",
+    "from langchain.agents import initialize_agent, AgentType\n",
+    "\n",
+    "llm = ChatOllama(model='llama3.2')\n",
+    "agent = initialize_agent([run_quality_check], llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent.run('Check doc123 for missing clauses.')\n",
+    "agent.run('Run a quality check on doc124.')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3", 
+   "language": "python", 
+   "name": "python3" 
+  },
+  "language_info": {
+   "name": "python" 
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `quality_check_demo.ipynb` notebook that generates sample contracts
- set up a Flask endpoint for quality checking .docx files
- expose a LangChain tool and agent using ChatOllama model
- run demo queries via the agent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e3a8baab0832b9a219d2045dd9972